### PR TITLE
Pull actual data from the server instead of directly return in benchmark

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -1,66 +1,80 @@
-use istziio_client::client_api::{StorageRequest, StorageClient};
-use std::path::PathBuf;
-use std::time::Instant;
-use tokio::sync::mpsc;
-use std::time::{Duration, SystemTime};
-use std::thread::sleep;
-use std::collections::VecDeque;
-use std::error::Error;
 use csv;
+use istziio_client::client_api::{StorageClient, StorageRequest};
+use std::error::Error;
+use std::path::PathBuf;
+use std::thread::sleep;
+use std::time::Instant;
+use std::time::{Duration, SystemTime};
+use tokio::sync::mpsc;
 
 // This scans the bench_files dir to figure out which test files are present,
 // then builds a map of TableId -> filename to init storage client(only when catalog is not available)
 // and also generates workload based on table ids. Finally it runs the workload
 
-
-
 pub struct TraceEntry {
     pub timestamp: u64,
-    pub request: StorageRequest
+    pub request: StorageRequest,
 }
 
 pub enum ClientType {
     Client1(),
-    Client2()
+    Client2(),
 }
 
-pub fn parse_trace(trace_path: PathBuf) -> Result<VecDeque<TraceEntry>, Box<dyn Error>> {
-    let mut trace: VecDeque<TraceEntry> = VecDeque::new();
+pub fn parse_trace(trace_path: PathBuf) -> Result<Vec<TraceEntry>, Box<dyn Error>> {
     let mut rdr = csv::Reader::from_path(trace_path)?;
+    let mut traces = Vec::new();
     for result in rdr.records() {
-        // The iterator yields Result<StringRecord, Error>, so we check the
-        // error here.
         let record = result?;
-        trace.push_back(TraceEntry{timestamp: record.get(0).unwrap().parse().unwrap(), request: StorageRequest::Table(record.get(1).unwrap().parse().unwrap())});
+        traces.push(TraceEntry {
+            timestamp: record.get(0).unwrap().parse().unwrap(),
+            request: StorageRequest::Table(record.get(1).unwrap().parse().unwrap()),
+        });
     }
-    Ok(trace)
+    Ok(traces)
 }
-pub async fn run_trace(mut trace: VecDeque<TraceEntry>, client_builder: &dyn Fn() -> Box<dyn StorageClient>) {
+
+pub async fn run_trace(
+    traces: Vec<TraceEntry>,
+    client_builder: &dyn Fn() -> Box<dyn StorageClient>,
+) {
     let start_time = SystemTime::now();
-    let request_num = trace.len();
+    let request_num = traces.len();
     let (tx, mut rx) = mpsc::channel(32);
-    while !trace.is_empty() {
-        let next_entry = trace.pop_front().unwrap();
-        if let Some(diff) = Duration::from_millis(next_entry.timestamp).checked_sub(start_time.elapsed().unwrap()) {
+    for (i, trace) in traces.into_iter().enumerate() {
+        if let Some(diff) =
+            Duration::from_millis(trace.timestamp).checked_sub(start_time.elapsed().unwrap())
+        {
             sleep(diff);
         }
-        println!("next trace: {}", next_entry.timestamp);
         let tx = tx.clone();
         let client = client_builder();
         tokio::spawn(async move {
-            let table_id = match next_entry.request {
+            let table_id = match trace.request {
                 StorageRequest::Table(id) => id,
                 _ => panic!("Invalid request type"),
             };
-            println!("start thread reading {}", table_id);
+            println!(
+                "Trace {} sends request for table {} at timestamp {}",
+                i, table_id, trace.timestamp
+            );
             let client_start = Instant::now();
-            let req = next_entry.request;
+            let req = trace.request;
 
-            let res = client.request_data_sync(req.clone()).await;
-            if let Err(e) = res {
-                println!("Error: {}", e);
+            let res = client.request_data(req.clone()).await;
+            if res.is_err() {
+                println!("Error: {}", res.as_ref().err().unwrap());
+            }
+            let mut rx = res.unwrap();
+            let mut total_num_rows = 0;
+            while let Some(rb) = rx.recv().await {
+                total_num_rows += rb.num_rows();
             }
             let client_duration = client_start.elapsed();
+            println!(
+                "Trace {} gets {} rows from the client, latency is {:?}",
+                i, total_num_rows, client_duration
+            );
             tx.send(client_duration).await.unwrap();
         });
     }
@@ -69,7 +83,6 @@ pub async fn run_trace(mut trace: VecDeque<TraceEntry>, client_builder: &dyn Fn(
     let mut duration_sum = Duration::new(0, 0);
     for _ in 0..request_num {
         let client_duration = rx.recv().await.unwrap();
-        println!("Client latency: {:?}", client_duration);
         duration_sum += client_duration;
     }
 

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -1,4 +1,3 @@
-use csv;
 use istziio_client::client_api::{StorageClient, StorageRequest};
 use std::error::Error;
 use std::path::PathBuf;
@@ -59,9 +58,8 @@ pub async fn run_trace(
                 i, table_id, trace.timestamp
             );
             let client_start = Instant::now();
-            let req = trace.request;
 
-            let res = client.request_data(req.clone()).await;
+            let res = client.request_data(trace.request).await;
             if res.is_err() {
                 println!("Error: {}", res.as_ref().err().unwrap());
             }


### PR DESCRIPTION
Previously, the benchmark runner did not pull any actual data from the server. Instead, it directly terminates the channel after getting the receiver. Running the previous code on `ParpulseStorageClientImpl` will give out the following error:

```
thread 'tokio-runtime-worker' panicked at /home/ubuntu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/parpulse-client-0.1.0/src/client.rs:109:39:
called `Result::unwrap()` on an `Err` value: SendError { .. }
```

This PR fixes the problem. It also takes into account the time that the client pulls ALL data from the server. The `client_duration` is now calculated as the total time from the client issuing the request till the client gets ALL data from the server.